### PR TITLE
fix link displayed when running locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build": "rollup -c",
     "coverage": "vitest run --coverage --coverage.include=src",
     "lint": "eslint",
-    "start": "http-server",
+    "start": "http-server -a localhost",
     "test": "vitest run"
   },
   "type": "module"


### PR DESCRIPTION
Before, (at least on my machine), running `npm run start` showed three ips which didn't work in the console:

```shell
Available on:
  http://127.0.0.1:8080
  http://192.168.0.11:8080
  http://100.109.63.115:8080
```

Now, it shows `localhost`, which is allowed on Google Maps:

```shell
Available on:
  http://localhost:8080
```

Closes #8